### PR TITLE
Add multi-architecture support for Debian package builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,19 @@ on:
         description: The build version.
         type: string
         required: true
+      architecture:
+        description: Architecture to build (amd64, arm64, armel, armhf, ppc64el, s390x, riscv64, or 'all' for all architectures)
+        type: choice
+        default: 'all'
+        options:
+          - 'all'
+          - 'amd64'
+          - 'arm64'
+          - 'armel'
+          - 'armhf'
+          - 'ppc64el'
+          - 's390x'
+          - 'riscv64'
 
 permissions:
   contents: write
@@ -24,7 +37,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Build uv
-        run: ./build.sh ${{ inputs.uv_version }} ${{ inputs.build_version }}
+        run: ./build.sh ${{ inputs.uv_version }} ${{ inputs.build_version }} ${{ inputs.architecture }}
       
       - name: Upload Artifact
         uses: actions/upload-artifact@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,14 @@ ARG DEBIAN_DIST
 ARG uv_VERSION
 ARG BUILD_VERSION
 ARG FULL_VERSION
+ARG ARCH
+ARG UV_RELEASE
 
 RUN mkdir -p /output/usr/bin
 RUN mkdir -p /output/usr/share/doc/uv
 RUN mkdir -p /output/DEBIAN
 
-COPY uv-x86_64-unknown-linux-musl/* /output/usr/bin/
+COPY ${UV_RELEASE}/* /output/usr/bin/
 COPY output/DEBIAN/control /output/DEBIAN/
 COPY output/copyright /output/usr/share/doc/uv/
 COPY output/changelog.Debian /output/usr/share/doc/uv/
@@ -21,5 +23,6 @@ RUN sed -i "s/FULL_VERSION/$FULL_VERSION/" /output/usr/share/doc/uv/changelog.De
 RUN sed -i "s/DIST/$DEBIAN_DIST/" /output/DEBIAN/control
 RUN sed -i "s/uv_VERSION/$uv_VERSION/" /output/DEBIAN/control
 RUN sed -i "s/BUILD_VERSION/$BUILD_VERSION/" /output/DEBIAN/control
+RUN sed -i "s/SUPPORTED_ARCHITECTURES/$ARCH/" /output/DEBIAN/control
 
 RUN dpkg-deb --build /output /uv_${FULL_VERSION}.deb

--- a/README.md
+++ b/README.md
@@ -19,10 +19,20 @@
 This repository contains build scripts to produce the _unofficial_ Debian packages
 (.deb) for [uv](https://github.com/astral-sh/uv/) hosted at [debian.griffo.io](https://debian.griffo.io)
 
-Currently supported debian distros are:
-- Bookworm
-- Trixie
-- Sid
+Currently supported Debian distros are:
+- Bookworm (v12)
+- Trixie (v13)
+- Forky (v14)
+- Sid (testing)
+
+Supported architectures:
+- amd64 (x86_64) - All distributions
+- arm64 (aarch64) - All distributions
+- armel (ARM EABI) - All distributions
+- armhf (ARM hard float) - All distributions
+- ppc64el (PowerPC 64-bit little endian) - All distributions
+- s390x (IBM System z) - All distributions
+- riscv64 (RISC-V 64-bit) - Trixie, Forky, Sid only
 
 This is an unofficial community project to provide a package that's easy to
 install on Debian. If you're looking for the uv source code, see
@@ -51,10 +61,25 @@ sudo dpkg -i <filename>.deb
 
 To update to a new version, just follow any of the installation methods above. There's no need to uninstall the old version; it will be updated correctly.
 
+## Building
+
+### Build for single architecture
+```sh
+./build.sh <uv_version> <build_version> <architecture>
+# Example: ./build.sh 0.8.11 1 arm64
+```
+
+### Build for all architectures
+```sh
+./build.sh <uv_version> <build_version> all
+# Example: ./build.sh 0.8.11 1 all
+```
+
 ## Roadmap
 
 - [x] Produce a .deb package on GitHub Releases
 - [x] Set up a debian mirror for easier updates
+- [x] Multi-architecture support (amd64, arm64, armel, armhf, ppc64el, s390x)
 
 ## Disclaimer
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Currently supported Debian distros are:
 - Forky (v14)
 - Sid (testing)
 
+Thanks to @ranjithrajv
 Supported architectures:
 - amd64 (x86_64) - All distributions
 - arm64 (aarch64) - All distributions

--- a/build.sh
+++ b/build.sh
@@ -1,18 +1,146 @@
 uv_VERSION=$1
 BUILD_VERSION=$2
+ARCH=${3:-amd64}  # Default to amd64 if no architecture specified
 
-wget https://github.com/astral-sh/uv/releases/download/${uv_VERSION}/uv-x86_64-unknown-linux-musl.tar.gz && tar -xf uv-x86_64-unknown-linux-musl.tar.gz && rm -f uv-x86_64-unknown-linux-musl.tar.gz
+if [ -z "$uv_VERSION" ] || [ -z "$BUILD_VERSION" ]; then
+    echo "Usage: $0 <uv_version> <build_version> [architecture]"
+    echo "Example: $0 0.8.11 1 arm64"
+    echo "Example: $0 0.8.11 1 all    # Build for all architectures"
+    echo "Supported architectures: amd64, arm64, armel, armhf, ppc64el, s390x, riscv64, all"
+    exit 1
+fi
 
-declare -a arr=("bookworm" "trixie" "forky" "sid")
+# Function to map Debian architecture to uv release name
+get_uv_release() {
+    local arch=$1
+    case "$arch" in
+        "amd64")
+            echo "uv-x86_64-unknown-linux-musl"
+            ;;
+        "arm64")
+            echo "uv-aarch64-unknown-linux-musl"
+            ;;
+        "armel")
+            echo "uv-arm-unknown-linux-musleabihf"
+            ;;
+        "armhf")
+            echo "uv-armv7-unknown-linux-musleabihf"
+            ;;
+        "ppc64el")
+            echo "uv-powerpc64le-unknown-linux-gnu"
+            ;;
+        "s390x")
+            echo "uv-s390x-unknown-linux-gnu"
+            ;;
+        "riscv64")
+            echo "uv-riscv64gc-unknown-linux-gnu"
+            ;;
+        *)
+            echo ""
+            ;;
+    esac
+}
 
-for i in "${arr[@]}"
-do
-  DEBIAN_DIST=$i
-  FULL_VERSION=$uv_VERSION-${BUILD_VERSION}+${DEBIAN_DIST}_amd64
-docker build . -t uv-$DEBIAN_DIST  --build-arg DEBIAN_DIST=$DEBIAN_DIST --build-arg uv_VERSION=$uv_VERSION --build-arg BUILD_VERSION=$BUILD_VERSION --build-arg FULL_VERSION=$FULL_VERSION
-  id="$(docker create uv-$DEBIAN_DIST)"
-  docker cp $id:/uv_$FULL_VERSION.deb - > ./uv_$FULL_VERSION.deb
-  tar -xf ./uv_$FULL_VERSION.deb
-done
+# Function to build for a specific architecture
+build_architecture() {
+    local build_arch=$1
+    local uv_release
+    
+    uv_release=$(get_uv_release "$build_arch")
+    if [ -z "$uv_release" ]; then
+        echo "❌ Unsupported architecture: $build_arch"
+        echo "Supported architectures: amd64, arm64, armel, armhf, ppc64el, s390x, riscv64"
+        return 1
+    fi
+    
+    echo "Building for architecture: $build_arch using $uv_release"
+    
+    # Clean up any previous builds for this architecture
+    rm -rf "$uv_release" || true
+    rm -f "${uv_release}.tar.gz" || true
+    
+    # Download and extract uv binary for this architecture
+    if ! wget "https://github.com/astral-sh/uv/releases/download/${uv_VERSION}/${uv_release}.tar.gz"; then
+        echo "❌ Failed to download uv binary for $build_arch"
+        return 1
+    fi
+    
+    if ! tar -xf "${uv_release}.tar.gz"; then
+        echo "❌ Failed to extract uv binary for $build_arch"
+        return 1
+    fi
+    
+    rm -f "${uv_release}.tar.gz"
+    
+    # Build packages for appropriate Debian distributions
+    # riscv64 is only supported in trixie (v13) and later, not in bookworm (v12)
+    if [ "$build_arch" = "riscv64" ]; then
+        declare -a arr=("trixie" "forky" "sid")
+    else
+        declare -a arr=("bookworm" "trixie" "forky" "sid")
+    fi
+    
+    for dist in "${arr[@]}"; do
+        FULL_VERSION="$uv_VERSION-${BUILD_VERSION}+${dist}_${build_arch}"
+        echo "  Building $FULL_VERSION"
+        
+        if ! docker build . -t "uv-$dist-$build_arch" \
+            --build-arg DEBIAN_DIST="$dist" \
+            --build-arg uv_VERSION="$uv_VERSION" \
+            --build-arg BUILD_VERSION="$BUILD_VERSION" \
+            --build-arg FULL_VERSION="$FULL_VERSION" \
+            --build-arg ARCH="$build_arch" \
+            --build-arg UV_RELEASE="$uv_release"; then
+            echo "❌ Failed to build Docker image for $dist on $build_arch"
+            return 1
+        fi
+        
+        id="$(docker create "uv-$dist-$build_arch")"
+        if ! docker cp "$id:/uv_$FULL_VERSION.deb" - > "./uv_$FULL_VERSION.deb"; then
+            echo "❌ Failed to extract .deb package for $dist on $build_arch"
+            return 1
+        fi
+        
+        if ! tar -xf "./uv_$FULL_VERSION.deb"; then
+            echo "❌ Failed to extract .deb contents for $dist on $build_arch"
+            return 1
+        fi
+    done
+    
+    # Clean up extracted directory
+    rm -rf "$uv_release" || true
+    
+    echo "✅ Successfully built for $build_arch"
+    return 0
+}
 
-
+# Main build logic
+if [ "$ARCH" = "all" ]; then
+    echo "🚀 Building uv $uv_VERSION-$BUILD_VERSION for all supported architectures..."
+    echo ""
+    
+    # All supported architectures
+    ARCHITECTURES=("amd64" "arm64" "armel" "armhf" "ppc64el" "s390x" "riscv64")
+    
+    for build_arch in "${ARCHITECTURES[@]}"; do
+        echo "==========================================="
+        echo "Building for architecture: $build_arch"
+        echo "==========================================="
+        
+        if ! build_architecture "$build_arch"; then
+            echo "❌ Failed to build for $build_arch"
+            exit 1
+        fi
+        
+        echo ""
+    done
+    
+    echo "🎉 All architectures built successfully!"
+    echo "Generated packages:"
+    ls -la uv_*.deb
+else
+    # Build for single architecture
+    if ! build_architecture "$ARCH"; then
+        exit 1
+    fi
+fi

--- a/output/DEBIAN/control
+++ b/output/DEBIAN/control
@@ -4,6 +4,6 @@ Maintainer: Dario Griffo <dariogriffo@gmail.com>
 Homepage: https://github.com/astral-sh/uv
 Package: uv
 Version: uv_VERSION-BUILD_VERSION+DIST
-Architecture: ARCH_PLACEHOLDER
+Architecture: SUPPORTED_ARCHITECTURES
 Description: An extremely fast Python package and project manager, written in Rust.
 

--- a/output/DEBIAN/control
+++ b/output/DEBIAN/control
@@ -4,6 +4,6 @@ Maintainer: Dario Griffo <dariogriffo@gmail.com>
 Homepage: https://github.com/astral-sh/uv
 Package: uv
 Version: uv_VERSION-BUILD_VERSION+DIST
-Architecture: amd64
+Architecture: ARCH_PLACEHOLDER
 Description: An extremely fast Python package and project manager, written in Rust.
 


### PR DESCRIPTION
  - Add support for arm64, armel, armhf, ppc64el, s390x, and riscv64 architectures
  - Implement conditional distribution support (riscv64 only for trixie/forky/sid)
  - Enhance build.sh with architecture mapping and 'all' option for building all archs
  - Add architecture parameter to GitHub Actions workflow with dropdown selection
  - Fix hardcoded architecture references using proper template placeholders
  - Update documentation with supported architectures and distribution matrix
  - Improve error handling and progress reporting in build process